### PR TITLE
Update policies and operator install/remove.

### DIFF
--- a/security/operator/install.yaml
+++ b/security/operator/install.yaml
@@ -3,7 +3,8 @@
   connection: local
   vars:
     image_repo: dockerhub.com
-    image_name: fullboar/secops-operator:latest
+    image_name: fullboar/secops-operator
+    image_tag: latest
   tasks:
     - name: Process the operator manifest template
       template:

--- a/security/operator/install.yaml
+++ b/security/operator/install.yaml
@@ -1,0 +1,19 @@
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  vars:
+    image_repo: dockerhub.com
+    image_name: fullboar/secops-operator:latest
+  tasks:
+    - name: Process the operator manifest template
+      template:
+        src: secopspolicy/deploy/operator.yaml.j2
+        dest: secopspolicy/deploy/operator.yaml
+    - name: Install
+      shell: |
+        /usr/local/bin/kubectl apply \
+        -f secopspolicy/deploy/crds/defenition.yaml \
+        -f secopspolicy/deploy/role.yaml \
+        -f secopspolicy/deploy/role_binding.yaml \
+        -f secopspolicy/deploy/service_account.yaml \
+        -f secopspolicy/deploy/operator.yaml

--- a/security/operator/secopspolicy/create_netpol.yaml
+++ b/security/operator/secopspolicy/create_netpol.yaml
@@ -1,8 +1,9 @@
 # This collection of tasks will create an Aporeto
 # `networkaccesspolicies` policy.
 # Variables
-#   - pol_uid
+#   - pol_uuid
 #   - k8s_uuid
+#   - apo_namespace
 #   - netpol_spec
 # Sets
 #   - policy_id
@@ -10,7 +11,7 @@
     data: "{{ data|default({}) | combine( {item.variable: item.value} ) }}"
   with_items:
   - variable: name
-    value: "inter-ns-network-{{ pol_uid }}"
+    value: "inter-ns-network-{{ pol_uuid }}"
   - variable: description
     value: "{{ netpol_spec.description | replace('\n', ' ') }}"
   - variable: associatedTags
@@ -26,11 +27,11 @@
   debug: 
     msg: "apoctl data = {{ data }}"
 - name: Create policy
-  when: data is defined and namespace is defined
+  when: data is defined and apo_namespace is defined
   shell: | 
     /usr/local/bin/apoctl \
     api create networkaccesspolicies \
-    --namespace "{{ namespace }}" \
+    --namespace "{{ apo_namespace }}" \
     -d '{{ data | to_json }}'
   register: output
 - name: Debug - policy id 

--- a/security/operator/secopspolicy/deploy/crds/defenition.yaml
+++ b/security/operator/secopspolicy/deploy/crds/defenition.yaml
@@ -1,13 +1,13 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: secopspolicies.secops.pathfinder.gov.bc.ca
+  name: networksecurity.secops.pathfinder.gov.bc.ca
 spec:
   group: secops.pathfinder.gov.bc.ca
   names:
     kind: NetworkSecurityPolicy
     listKind: SecOpsPolicyList
-    plural: secopspolicies
+    plural: networksecurity
     singular: networksecuritypolicy
   scope: Namespaced
   subresources:

--- a/security/operator/secopspolicy/deploy/crds/defenition.yaml
+++ b/security/operator/secopspolicy/deploy/crds/defenition.yaml
@@ -9,7 +9,7 @@ spec:
     listKind: SecOpsPolicyList
     plural: networksecuritypolicies
     singular: networksecuritypolicy
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   version: v1alpha1

--- a/security/operator/secopspolicy/deploy/crds/defenition.yaml
+++ b/security/operator/secopspolicy/deploy/crds/defenition.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: networksecurity.secops.pathfinder.gov.bc.ca
+  name: networksecuritypolicies.secops.pathfinder.gov.bc.ca
 spec:
   group: secops.pathfinder.gov.bc.ca
   names:

--- a/security/operator/secopspolicy/deploy/crds/defenition.yaml
+++ b/security/operator/secopspolicy/deploy/crds/defenition.yaml
@@ -7,7 +7,7 @@ spec:
   names:
     kind: NetworkSecurityPolicy
     listKind: SecOpsPolicyList
-    plural: networksecurity
+    plural: networksecuritypolicies
     singular: networksecuritypolicy
   scope: Namespaced
   subresources:

--- a/security/operator/secopspolicy/deploy/operator.yaml.j2
+++ b/security/operator/secopspolicy/deploy/operator.yaml.j2
@@ -19,16 +19,14 @@ spec:
           - /usr/local/bin/ao-logs
           - /tmp/ansible-operator/runner
           - stdout
-          # Replace this with the built image name
-          image: "{{ image_repo }}/{{ image_name }}"
+          image: "{{ image_repo }}/{{ image_name }}:{{ image_tag }}"
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: operator
-          # Replace this with the built image name
-          image: "{{ image_name }}"
+          image: "{{ image_repo }}/{{ image_name }}:{{ image_tag }}"
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner

--- a/security/operator/secopspolicy/deploy/operator.yaml.j2
+++ b/security/operator/secopspolicy/deploy/operator.yaml.j2
@@ -20,16 +20,16 @@ spec:
           - /tmp/ansible-operator/runner
           - stdout
           # Replace this with the built image name
-          image: "jasoncleach/operator:latest"
-          imagePullPolicy: "Always"
+          image: "{{ image_repo }}/{{ image_name }}"
+          imagePullPolicy: "IfNotPresent"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: operator
           # Replace this with the built image name
-          image: "jasoncleach/operator:latest"
-          imagePullPolicy: "Always"
+          image: "{{ image_name }}"
+          imagePullPolicy: "IfNotPresent"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner

--- a/security/operator/secopspolicy/lookup_netpol.yaml
+++ b/security/operator/secopspolicy/lookup_netpol.yaml
@@ -3,15 +3,15 @@
 # known tag.
 # Variables
 #   - k8s_uuid
-#   - appo_namespace
+#   - apo_namespace
 # Sets
 #   - policy_id
 - name: Policy Lookup
-  when: k8s_uuid is defined and appo_namespace is defined
+  when: k8s_uuid is defined and apo_namespace is defined
   shell: |
     /usr/local/bin/apoctl \
     api list networkaccesspolicies \
-    --namespace "{{ appo_namespace }}" \
+    --namespace "{{ apo_namespace }}" \
     --filter "associatedTags contains k8s-uuid={{ k8s_uuid }}" \
     -c ID
   register: output

--- a/security/operator/secopspolicy/playbook.yaml
+++ b/security/operator/secopspolicy/playbook.yaml
@@ -2,7 +2,7 @@
   gather_facts: no
   vars:
     k8s_message_key: _secops_pathfinder_gov_bc_ca_networksecuritypolicy
-    namespace: /bcgov-devex/lab
+    apo_base_namespace: /bcgov/lab
   tasks:
     - import_role:
         name: "networksecuritypolicy"
@@ -23,7 +23,7 @@
     - import_tasks: lookup_netpol.yaml
       vars:
         k8s_uuid: "{{  metadata.uid  }}"
-        appo_namespace: "{{ namespace }}"
+        apo_namespace: "{{  apo_base_namespace }}/{{ metadata.namespace }}"
     - name: Debug Information
       when: policy_id is defined
       debug: 
@@ -35,8 +35,9 @@
     # exists.
     - import_tasks: create_netpol.yaml
       vars:
-        pol_uid: "{{ puid }}"
+        pol_uuid: "{{ puid }}"
         k8s_uuid: "{{ metadata.uid }}"
+        apo_namespace: "{{  apo_base_namespace }}/{{ metadata.namespace }}"
         netpol_spec: "{{ spec }}"
     # - name: Finished
     #   debug:

--- a/security/operator/secopspolicy/playbook.yaml
+++ b/security/operator/secopspolicy/playbook.yaml
@@ -2,7 +2,7 @@
   gather_facts: no
   vars:
     k8s_message_key: _secops_pathfinder_gov_bc_ca_networksecuritypolicy
-    apo_base_namespace: /bcgov/lab
+    apo_base_namespace: /bcgov/test
   tasks:
     - import_role:
         name: "networksecuritypolicy"
@@ -28,7 +28,17 @@
       when: policy_id is defined
       debug: 
         msg: "Found existing policy with ID {{ policy_id }}"
-    - name: Exist if policy exists
+
+    - import_tasks: update_netpol.yaml
+      when: policy_id is defined
+      vars:
+        policy_id: "{{ policy_id }}"
+        pol_uuid: "{{ puid }}"
+        k8s_uuid: "{{ metadata.uid }}"
+        apo_namespace: "{{  apo_base_namespace }}/{{ metadata.namespace }}"
+        netpol_spec: "{{ spec }}"
+
+    - name: Finished
       when: policy_id is defined
       meta: end_play
     # Create a policy if it does not already

--- a/security/operator/secopspolicy/update_netpol.yaml
+++ b/security/operator/secopspolicy/update_netpol.yaml
@@ -1,0 +1,49 @@
+# This collection of tasks will patch/update an existing Aporeto
+# `networkaccesspolicies` policy.
+# Variables
+#   - policy_id
+#   - pol_uuid
+#   - k8s_uuid
+#   - apo_namespace
+#   - netpol_spec
+# Sets
+#   - policy_id
+- set_fact:
+    data: "{{ data|default({}) | combine( {item.variable: item.value} ) }}"
+  with_items:
+  # Incremental updates are not possible as of 2019/09/10; all properties present
+  # during the create must be exist during the update.
+  - variable: name
+    value: "inter-ns-network-{{ pol_uuid }}"
+  - variable: description
+    value: "{{ netpol_spec.description | replace('\n', ' ') }}"
+  - variable: associatedTags
+    value:
+      - k8s-uuid={{ k8s_uuid }}
+  - variable: object
+    value: 
+      - - "$namespace={{ netpol_spec.destination }}"
+  - variable: subject
+    value:
+      - - "$namespace={{ netpol_spec.source }}"
+- name: Debug - extracted variables
+  debug: 
+    msg: "apoctl data = {{ data }}"
+- name: Debug - policy id 
+  debug: 
+    msg: "blarb = {{ netpol_spec }}"
+- name: Patch policy
+  when: data is defined and apo_namespace is defined
+  shell: | 
+    /usr/local/bin/apoctl \
+    api update networkaccesspolicies "{{ policy_id }}" \
+    --namespace "{{ apo_namespace }}" \
+    -d '{{ data | to_json }}'
+  register: output
+- name: Debug - policy id 
+  debug: 
+    msg: "Patching policy with ID {{ output.stdout }}"
+- name: Extract policy id
+  when: output.stdout != ""
+  set_fact:
+    policy_id: "{{ output.stdout }}"


### PR DESCRIPTION
This PR takes care of some feedback from previous issues:

#135 Added ability to update an existing policy;
#135 Changed scope from `Namespace` to `Cluster`;
#135 General code cleanup.

#177 Initial work on install playbook.