### PR TITLE
Allow for more complex network access policies

### DIFF
--- a/security/operator/README.md
+++ b/security/operator/README.md
@@ -49,6 +49,7 @@ Link the the operator `roles` and `playbook.yaml` so that ansible can access the
 
 ```console
 ln -s $PWD/roles /opt/ansible/roles
+ln -s $PWD/templates /opt/ansible/templates
 ln -s $PWD/*.yaml /opt/ansible/
 ```
 

--- a/security/operator/secopspolicy/deploy/crds/netpol-sample.yaml
+++ b/security/operator/secopspolicy/deploy/crds/netpol-sample.yaml
@@ -6,5 +6,10 @@ spec:
   description: |
     allow the devhub namespace to talk to the VON
     namespace.
-  destination: blarb1
-  source: blarb2
+  source:
+    - - $namespace=blarb2
+    - - app=web
+  destination:
+    - - $namespace=blarb1
+    - - env=prod
+      - app=api

--- a/security/operator/secopspolicy/import_netpol.yaml
+++ b/security/operator/secopspolicy/import_netpol.yaml
@@ -7,14 +7,14 @@
 #   - netpol_spec
 - name: Process j2 template
   template:
-    src: ./templates/inter-ns-pol.yaml.j2
-    dest: "/tmp/inter-ns-pol-{{ pol_uuid }}.yaml"
+    src: ./templates/custom-netpol.yaml.j2
+    dest: "/tmp/custom-netpol-{{ pol_uuid }}.yaml"
 - name: Create policy
   shell: | 
     /usr/local/bin/apoctl api import \
     --namespace {{ apo_namespace }} \
-    --file "/tmp/inter-ns-pol-{{ pol_uuid }}.yaml"
+    --file "/tmp/custom-netpol-{{ pol_uuid }}.yaml"
 - name: Cleanup template
   file:
-    path: "/tmp/inter-ns-pol-{{ pol_uuid }}.yaml"
+    path: "/tmp/custom-netpol-{{ pol_uuid }}.yaml"
     state: absent

--- a/security/operator/secopspolicy/templates/custom-netpol.yaml.j2
+++ b/security/operator/secopspolicy/templates/custom-netpol.yaml.j2
@@ -3,10 +3,10 @@
 #}
 {% set base = lookup('env', 'APOCTL_BASE_NAMESPACE') %}
 APIVersion: 1
-label: inter-ns-network-{{ pol_uuid }}
+label: custom-netpol-{{ pol_uuid }}
 data:
   networkaccesspolicies:
-  - name: inter-ns-network-{{ pol_uuid }}
+  - name: custom-netpol-{{ pol_uuid }}
     description: {{ netpol_spec.description | replace('\n', ' ') }}
     action: {{ netpol_spec.action | default("Allow") }}
     propagate: true

--- a/security/operator/secopspolicy/templates/inter-ns-pol.yaml.j2
+++ b/security/operator/secopspolicy/templates/inter-ns-pol.yaml.j2
@@ -1,33 +1,81 @@
+{#
+    Set global variables.
+#}
+{% set base = lookup('env', 'APOCTL_BASE_NAMESPACE') %}
 APIVersion: 1
 label: inter-ns-network-{{ pol_uuid }}
 data:
   networkaccesspolicies:
   - name: inter-ns-network-{{ pol_uuid }}
     description: {{ netpol_spec.description | replace('\n', ' ') }}
-    action: "Allow"
+    action: {{ netpol_spec.action | default("Allow") }}
     propagate: true
     logsEnabled: true
-    object:
-{% if '/bcgov' in netpol_spec.destination %}
-    - - $namespace={{ netpol_spec.destination }}
-{% else %}
-{% if  netpol_spec.destination.startswith('/') %}
-{% set destination = netpol_spec.destination[1:] %}
-{% else %}
-{% set source = netpol_spec.destination %}
-{% endif %}
-    - - $namespace={{ lookup('env', 'APOCTL_BASE_NAMESPACE') }}/{{ destination }}
-{% endif %}
+{#
+    Process `source` to `subject` properties
+#}
     subject:
-{% if '/bcgov' in netpol_spec.source %}
-    - - $namespace={{ netpol_spec.source }}
-{% else %}
-{% if  netpol_spec.source.startswith('/') %}
-{% set source = netpol_spec.source[1:] %}
-{% else %}
-{% set source = netpol_spec.source %}
+{% for items in netpol_spec.source %}
+{% for i in items %}
+{# 
+    If any item represents a namespace we need to make sure
+    that it represents a fully qualified namespace.
+#}
+{% if '$namespace' in i %}
+{% set value = i.split('=')[1] %}
+{% if base not in value %}
+{# String leading character so we can join later #}
+{% if  value.startswith('/') %}
+{% set value = value[1:] %}
 {% endif %}
-    - - $namespace={{ lookup('env', 'APOCTL_BASE_NAMESPACE') }}/{{ source }}
+{# Rebuild the namespace property #}
+{% set i = '$namespace=' + base + '/' + value %}
 {% endif %}
+{% endif %}
+{# 
+    The first item needs to be preceeded with two dashes `- -` while
+    subsaquent items need only a single dash `-`; this groups them in
+    a logical AND.
+#}
+{% if loop.index == 1 %}
+    - - {{ i }}
+{% else %}
+      - {{ i }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{#
+    Process `destination` to `object` properties
+#}
+    object:
+{% for items in netpol_spec.destination %}
+{% for j in items %}
+{# 
+    If any item represents a namespace we need to make sure
+    that it represents a fully qualified namespace.
+#}
+{% if '$namespace' in j %}
+{% set value = j.split('=')[1] %}
+{% if base not in value %}
+{# String leading character so we can join later #}
+{% if  value.startswith('/') %}
+{% set value = value[1:] %}
+{% endif %}
+{# Rebuild the namespace property #}
+{% set j = '$namespace=' + base + '/' + value %}
+{% endif %}
+{% endif %}
+{# 
+    The first item needs to be preceeded with two dashes `- -` while
+    subsaquent items need only a single dash `-`; this groups them in
+    a logical AND.
+#}
+{% if loop.index == 1 %}
+    - - {{ j }}
+{% else %}
+      - {{ j }}
+{% endif %}
+{% endfor %}
+{% endfor %}
     associatedTags:
     - k8s-uuid={{ k8s_uuid }}


### PR DESCRIPTION
This PR:
- fixes issue #248 (ns to ns comms); and
- fixes issue #238 (pod to pod comms); and
- partially fixes issue #181; for #181 an additional PR will be created to allow creating network objects.

This changes builds on Aporeto's YAML syntax for arrays to indicate logical OR and AND operations when using multiple properties / labels. For example:

```yaml
apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
kind: NetworkSecurityPolicy
metadata:
  name: inter-namespace-comms
spec:
  description: |
    allow the devhub namespace to talk to the VON
    namespace.
  source:
    - - $namespace=blarb2
    - - app=web
  destination:
    - - $namespace=blarb1
    - - env=prod
      - app=api
```

In this example the source are interpreted as ($namespace=blarb2 **and** app=web) while the destination is interpreted as ($namespace=blarb1) **or** (env=prod **and** app=api). Here is how it looks in the Web console:

<img width="1256" alt="Screenshot 2019-09-19 13 44 31" src="https://user-images.githubusercontent.com/390891/65279730-c2ac1680-dae3-11e9-8db7-1ddff9dd6c3f.png">

A sample from Aporeto can be found [here](https://docs.aporeto.com/docs/main/guides/network-policies/allow-app/).