### PR TITLE
Add front matter to docs for better DevHub integration

### DIFF
--- a/security/aporeto/docs/CustomPolicy.md
+++ b/security/aporeto/docs/CustomPolicy.md
@@ -1,5 +1,10 @@
 ---
 description: Create bespoke NetworkSecurityPolicy to establish a Zero Trust security model in your environment.
+tags:
+- security
+- firewall
+- devsecops
+- networking
 ---
 
 # Custom Policy

--- a/security/aporeto/docs/CustomPolicy.md
+++ b/security/aporeto/docs/CustomPolicy.md
@@ -1,3 +1,7 @@
+---
+description: Create bespoke NetworkSecurityPolicy to establish a Zero Trust security model in your environment.
+---
+
 # Custom Policy
 
 ## Introduction

--- a/security/aporeto/docs/ExternalNetworks.md
+++ b/security/aporeto/docs/ExternalNetworks.md
@@ -1,5 +1,10 @@
 ---
 description: Use custom networks to limit egress and ingress to your Zero Trust environment.
+tags:
+- security
+- firewall
+- devsecops
+- networking
 ---
 
 # External Networks

--- a/security/aporeto/docs/ExternalNetworks.md
+++ b/security/aporeto/docs/ExternalNetworks.md
@@ -1,3 +1,7 @@
-## External Networks
+---
+description: Use custom networks to limit egress and ingress to your Zero Trust environment.
+---
+
+# External Networks
 
 This document is under construction.

--- a/security/aporeto/docs/QuickStart.md
+++ b/security/aporeto/docs/QuickStart.md
@@ -1,3 +1,7 @@
+---
+description: Quickly apply NetworkSecurityPolicy to get your pods communicating as a first step towards a Zero Trust environment.
+---
+
 # Quick Start
 
 ## Introduction

--- a/security/aporeto/docs/QuickStart.md
+++ b/security/aporeto/docs/QuickStart.md
@@ -1,5 +1,10 @@
 ---
 description: Quickly apply NetworkSecurityPolicy to get your pods communicating as a first step towards a Zero Trust environment.
+tags:
+- security
+- firewall
+- devsecops
+- networking
 ---
 
 # Quick Start

--- a/security/aporeto/docs/README.md
+++ b/security/aporeto/docs/README.md
@@ -1,3 +1,6 @@
+---
+description: Learn how to create a Zero Trust environment and apply network security best practices.
+---
 
 # Trust No One
 

--- a/security/aporeto/docs/README.md
+++ b/security/aporeto/docs/README.md
@@ -1,5 +1,10 @@
 ---
 description: Learn how to create a Zero Trust environment and apply network security best practices.
+tags:
+- security
+- firewall
+- devsecops
+- networking
 ---
 
 # Trust No One


### PR DESCRIPTION
I added front matter a.k.a a brief description to all the documents to better enable the DevHub to index and summarize the documents.