### PR TITLE
Increase Enfocer CPU Limit in PROD

### DIFF
--- a/security/aporeto/build/ansible/group_vars/prod.yml
+++ b/security/aporeto/build/ansible/group_vars/prod.yml
@@ -1,7 +1,7 @@
 # Aporeto Specific Details
 aporeto_release: 3.12.3
 aporeto_enforcer_memory_limit: '8Gi'
-aporeto_enforcer_cpu_limit: '1'
+aporeto_enforcer_cpu_limit: '2'
 openshift_project_prefix: devops-security-aporeto
 openshift_project_editors: 
   - jleach


### PR DESCRIPTION
Marcus advised that the enforcer can use up to 7.5m per pod. So with a cap of 250 pods per host we could need up to 1875m. So let's just set it to a nice round 2.