### PR TITLE
Fix issue preventing advanced NSP (#310)

### DIFF
--- a/security/operator/secopspolicy/templates/custom-netpol.yaml.j2
+++ b/security/operator/secopspolicy/templates/custom-netpol.yaml.j2
@@ -51,9 +51,9 @@ data:
     a logical AND.
 #}
 {% if loop.index == 1 %}
-    - - {{ i }}
+    - - "{{ i }}"
 {% else %}
-      - {{ i }}
+      - "{{ i }}"
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -84,9 +84,9 @@ data:
     a logical AND.
 #}
 {% if loop.index == 1 %}
-    - - {{ j }}
+    - - "{{ j }}"
 {% else %}
-      - {{ j }}
+      - "{{ j }}"
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
To write advanced policy we need to support multiple colons in the YAML spec. This fix allows this provided the YAML is valid; this is done by quoting strings with multiple colons. The quotation can be wither single quotes `'` or double quotes `"`.

Fixed #310 