### PR TITLE
Disable oper reconcile period

### DIFF
--- a/security/aporeto/operator/secopspolicy/Dockerfile
+++ b/security/aporeto/operator/secopspolicy/Dockerfile
@@ -25,7 +25,7 @@ RUN yes | yum update && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 
-RUN curl -sL curl -sL https://download.aporeto.com/apoctl/linux/apoctl \
+RUN curl -sL https://download.aporeto.com/apoctl/linux/apoctl \
     -o /usr/local/bin/apoctl && \
     chmod 755 /usr/local/bin/apoctl
 

--- a/security/aporeto/operator/secopspolicy/Dockerfile
+++ b/security/aporeto/operator/secopspolicy/Dockerfile
@@ -1,12 +1,10 @@
-FROM quay.io/operator-framework/ansible-operator:v0.8.2
+FROM quay.io/operator-framework/ansible-operator:v0.10.1
 
 USER 0
 
 ARG GITHUB_ORG=BCDevOps
-ARG OPERATOR_SDK_VERSION=0.8.1
+ARG OPERATOR_SDK_VERSION=0.10.1
 ARG ANSIBLE_VERSION=2.7.10
-ARG APORETO_CLI_VERSION=3.9.2
-ARG AQUA_CLI_VERSION=1.0.b119
 ENV SUMMARY="Operator Controller v${OPERATOR_VERSION}"  \
     DESCRIPTION="Operator Controller SDK v${OPERATOR_SDK_VERSION}, Ansible v${ANSIBLE_VERSION}"
 
@@ -27,7 +25,7 @@ RUN yes | yum update && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 
-RUN curl -sL https://download.aporeto.com/releases/release-${APORETO_CLI_VERSION}/apoctl/linux/apoctl \
+RUN curl -sL curl -sL https://download.aporeto.com/apoctl/linux/apoctl \
     -o /usr/local/bin/apoctl && \
     chmod 755 /usr/local/bin/apoctl
 

--- a/security/aporeto/operator/secopspolicy/build/Dockerfile
+++ b/security/aporeto/operator/secopspolicy/build/Dockerfile
@@ -25,7 +25,7 @@ RUN yes | yum update && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 
-RUN curl -sL curl -sL https://download.aporeto.com/apoctl/linux/apoctl \
+RUN curl -sL https://download.aporeto.com/apoctl/linux/apoctl \
     -o /usr/local/bin/apoctl && \
     chmod 755 /usr/local/bin/apoctl
 

--- a/security/aporeto/operator/secopspolicy/build/Dockerfile
+++ b/security/aporeto/operator/secopspolicy/build/Dockerfile
@@ -1,12 +1,10 @@
-FROM quay.io/operator-framework/ansible-operator:v0.8.2
+FROM quay.io/operator-framework/ansible-operator:v0.10.1
 
 USER 0
 
 ARG GITHUB_ORG=BCDevOps
-ARG OPERATOR_SDK_VERSION=0.8.1
+ARG OPERATOR_SDK_VERSION=0.10.1
 ARG ANSIBLE_VERSION=2.7.10
-ARG APORETO_CLI_VERSION=3.9.2
-ARG AQUA_CLI_VERSION=1.0.b119
 ENV SUMMARY="Operator Controller v${OPERATOR_VERSION}"  \
     DESCRIPTION="Operator Controller SDK v${OPERATOR_SDK_VERSION}, Ansible v${ANSIBLE_VERSION}"
 
@@ -27,7 +25,7 @@ RUN yes | yum update && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 
-RUN curl -sL https://download.aporeto.com/releases/release-${APORETO_CLI_VERSION}/apoctl/linux/apoctl \
+RUN curl -sL curl -sL https://download.aporeto.com/apoctl/linux/apoctl \
     -o /usr/local/bin/apoctl && \
     chmod 755 /usr/local/bin/apoctl
 

--- a/security/aporeto/operator/secopspolicy/extnet-destroy.yaml
+++ b/security/aporeto/operator/secopspolicy/extnet-destroy.yaml
@@ -20,7 +20,7 @@
         k8s_uuid: "{{  metadata.uid  }}"
         apo_kind: externalnetworks
         apo_namespace: "{{ lookup('env', 'APOCTL_BASE_NAMESPACE') }}/{{ metadata.namespace }}"
-    - name: Exist if no policy exists
+    - name: Exit if no policy exists
       when: policy_id is not defined
       meta: end_play
     - name: Delete Policy

--- a/security/aporeto/operator/secopspolicy/netsecpol-destroy.yaml
+++ b/security/aporeto/operator/secopspolicy/netsecpol-destroy.yaml
@@ -20,7 +20,7 @@
         k8s_uuid: "{{  metadata.uid  }}"
         apo_kind: networkaccesspolicies
         apo_namespace: "{{ lookup('env', 'APOCTL_BASE_NAMESPACE') }}/{{ metadata.namespace }}"
-    - name: Exist if no policy exists
+    - name: Exit if no policy exists
       when: policy_id is not defined
       meta: end_play
     - name: Delete Policy

--- a/security/aporeto/operator/secopspolicy/samples/complex-sample.yaml
+++ b/security/aporeto/operator/secopspolicy/samples/complex-sample.yaml
@@ -1,0 +1,14 @@
+apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+kind: NetworkSecurityPolicy
+metadata:
+  name: colon-testing
+spec:
+  description: |
+    test with an object such as a service account source
+  source:
+    - - "$namespace=ws-test"
+      - "@app:k8s:serviceaccountname=builder"
+    - - "$namespace=ws-test"
+      - "@app:k8s:serviceaccountname=deployer"
+  destination:
+    - - "int:network=internal-cluster-api-endpoint"

--- a/security/aporeto/operator/secopspolicy/watches.yaml
+++ b/security/aporeto/operator/secopspolicy/watches.yaml
@@ -2,8 +2,8 @@
 - version: v1alpha1
   group: secops.pathfinder.gov.bc.ca
   kind: NetworkSecurityPolicy
-  reconcilePeriod: 24h
-#  maxWorkers: 10
+  reconcilePeriod: 0s
+  watchDependentResources: False
   playbook: /opt/ansible/netsecpol-main.yaml
   finalizer:
     name: finalizer.secops.pathfinder.gov.bc.ca
@@ -11,7 +11,8 @@
 - version: v1alpha1
   group: secops.pathfinder.gov.bc.ca
   kind: ExternalNetwork
-  reconcilePeriod: 24h
+  reconcilePeriod: 0s
+  watchDependentResources: False
   playbook: /opt/ansible/extnet-main.yaml
   finalizer:
     name: finalizer.secops.pathfinder.gov.bc.ca


### PR DESCRIPTION
Reconciling thousands of CRs is notably time consuming and probably not that useful in his case. This PR:

- disables reconciliation; and
- ~~enables a watch dependencies feature that should achieve a similar result in edge cases (or it may do nothing); and~~
- updates to OperatorSDK v0.10.1 (last k8s 1.11 based version); and
- update to latest `apoctl`.

The watch dependencies option is documented [here](https://github.com/operator-framework/operator-sdk/blob/master/doc/ansible/dev/dependent_watches.md)

This PR may also fix an issue caused by the backwards compatibility of apoctl in the current version; it was unable to consistently create and delete policy until the cli was updated.

Tested CRUD against netpol in k8s environment.

Fixes #472