### PR TITLE
Add tls to statuspage

### DIFF
--- a/apps/statuspage/ansible/manifests/templates/template-envoy.yml.j2
+++ b/apps/statuspage/ansible/manifests/templates/template-envoy.yml.j2
@@ -112,6 +112,9 @@ items:
     host: {{ route }}
     port:
       targetPort: 10000-tcp
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
     to:
       kind: Service
       name: {{ envoy_service_name  }}


### PR DESCRIPTION
published status URL's are only using HTTP.  An HTTPS endpoint is requested.

modified the envoy external route to add tls (edge terminated) with no visible issues.