### PR TITLE
Add latency test scripts

### DIFF
--- a/security/aporeto/tools/latency-test/README.md
+++ b/security/aporeto/tools/latency-test/README.md
@@ -1,0 +1,40 @@
+
+To run this test setup the Hipster Store with the quick-start network security policy in place. For lab testing, make sure the `loadgenerator` and `frontend` pods are on different nodes. 
+
+Copy the test script in place:
+
+```console
+oc rsync test $(oc get pods -o name| grep loadgenerator):/tmp
+```
+
+Open a remote shell on the `loadgenerator` pod:
+
+```console
+oc rsh $(oc get pods -o name| grep loadgenerator)
+```
+
+The test has a 1sec delay between calls to the `frontend`. In the following example 1200 iterations will take approximatly 20min.
+
+```console
+cd /tmp/test && ./run.sh 1200 && exit
+```
+
+Fetch the results for processing
+```console
+oc rsync $(oc get pods -o name| grep loadgenerator):/tmp/test/ test
+```
+
+Analyse the results:
+
+```
+➜  latency-test git:(latency-test) ✗ node analize.js 
+Reporting On loadgenerator-6b4664dd7-7q8kx.dat
+    Sample Size: 1000
+       Min Time: 18ms
+       Max Time: 2791ms
+    Median Time: 258ms
+   Average Time: 289ms
+➜  latency-test git:(latency-test) ✗ 
+```
+
+You do not need to keep the *.dat files in the `test` directory.

--- a/security/aporeto/tools/latency-test/analize.js
+++ b/security/aporeto/tools/latency-test/analize.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+
+const scalar = 1000;
+const basePath = path.join(__dirname, 'test');
+
+const median = (data) => {
+    const sorted = data.map(d => d['time_total']).sort();
+    const midway = data.length / 2;
+    
+    if (sorted.length % 2) {
+        return sorted[midway];
+    }
+
+    return (sorted[midway - 1] + sorted[midway]) / 2.0;
+};
+
+const report = (data) => {
+    const averageTime = data.map(d => d['time_total']).reduce((a,c) => a+c) / data.length;
+    const maxTime = data.map(d => d['time_total']).reduce((a,c) => Math.max(a, c));
+    const minTime = data.map(d => d['time_total']).reduce((a,c) => Math.min(a, c));
+    
+    console.log(`    Sample Size: ${data.length}`);
+    console.log(`       Min Time: ${Math.round(minTime * scalar) / scalar * 1000}ms`);
+    console.log(`       Max Time: ${Math.round(maxTime * scalar) / scalar * 1000}ms`);
+    console.log(`    Median Time: ${Math.round(median(data) * scalar) / scalar * 1000}ms`);
+    console.log(`   Average Time: ${Math.round(averageTime * scalar) / scalar * 1000}ms`);
+};
+
+const main = async () => {
+    const contents = fs.readdirSync(basePath).filter(f => f.indexOf('.dat') >= 0);
+   
+    contents.forEach(f => {
+        const buff = fs.readFileSync(path.join(basePath, f));
+        const dataAsString = `[${buff.toString('utf8').trim().slice(0, -1)}]`;
+        const data = JSON.parse(dataAsString);
+    
+        console.log(`Reporting On ${f}`);
+        report(data);
+    });
+   
+
+    // const result = {};
+    // Object.keys(data[0]).forEach(key => {
+    //     result[key] = data.map(d => d[key]).reduce((a,c) => a+c);
+    // });
+};
+
+main();

--- a/security/aporeto/tools/latency-test/test/curl-format.txt
+++ b/security/aporeto/tools/latency-test/test/curl-format.txt
@@ -1,0 +1,9 @@
+{\n
+ "time_namelookup": %{time_namelookup},\n
+ "time_connect": %{time_connect},\n
+ "time_appconnect": %{time_appconnect},\n
+ "time_pretransfer": %{time_pretransfer},\n
+ "time_redirect": %{time_redirect},\n
+ "time_starttransfer": %{time_starttransfer},\n
+ "time_total": %{time_total}\n
+},\n

--- a/security/aporeto/tools/latency-test/test/run.sh
+++ b/security/aporeto/tools/latency-test/test/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Testing..."
+
+for ((i = 1; i <= $1; i++ )); do 
+    sleep 1
+    curl -w "@curl-format.txt" -o /dev/null -s "$FRONTEND_ADDR" >>$(hostname).dat
+done


### PR DESCRIPTION
To help test #581 I've created some scripts that will test latency between application components when we bring an enforcer down on different nodes. This PR adds them to our tools directory so we don't loose them.