### PR TITLE
Update Aporeto release version

### DIFF
--- a/security/aporeto/build/ansible/group_vars/lab.yml
+++ b/security/aporeto/build/ansible/group_vars/lab.yml
@@ -1,5 +1,5 @@
 # Aporeto Specific Details
-aporeto_release: 3.12.8
+aporeto_release: 3.13.2
 aporeto_enforcer_memory_limit: '4Gi'
 aporeto_enforcer_cpu_limit: '1'
 openshift_project_prefix: devops-security-aporeto

--- a/security/aporeto/build/ansible/group_vars/prod.yml
+++ b/security/aporeto/build/ansible/group_vars/prod.yml
@@ -1,5 +1,5 @@
 # Aporeto Specific Details
-aporeto_release: 3.12.8
+aporeto_release: 3.13.2
 aporeto_enforcer_memory_limit: '8Gi'
 aporeto_enforcer_cpu_limit: '2'
 openshift_project_prefix: devops-security-aporeto


### PR DESCRIPTION
Relevant changes in this version include:

- the enforcer in this release addresses the invalid token issue
- the operator in this release has an extended CRD for the PodInjectorSelector which allows you to configure the securityContext for the injected init container ... in your case as you are using the restricted SCC in some projects/namespaces ... the PodInjectorSelector can be configured to match one of the UIDs in the range of the project's UIDs