### PR TITLE
Adjust Aporeto Playbook for enforcer-infra DaemonSet

### DIFF
--- a/security/aporeto/build/ansible/tasks/install_aporeto_enforcers.yml
+++ b/security/aporeto/build/ansible/tasks/install_aporeto_enforcers.yml
@@ -1,24 +1,81 @@
 ---
+- name: Add the helm repo
+  command: "helm repo add {{ helm_repo_name }} {{ aporeto_repo }}"
+
 - name: Fetch helm charts for enforcers
   command: "helm fetch aporeto/enforcerd"
   
 - name: Use Helm Template to create OpenShift Objects
-  shell: "helm template enforcerd-*.tgz \
-  --namespace {{ openshift_project_prefix }}-enforcers \
-  --set resources.enabled=true \
-  --set resources.limits.memory={{ aporeto_enforcer_memory_limit }} \ 
-  --set resources.limits.cpu={{ aporeto_enforcer_cpu_limit }} \
-  --set options.enableCompressedTags=1 \
-  | oc apply -f - -n {{ openshift_project_prefix }}-enforcers "
+  shell: "helm template enforcerd-*.tgz -x templates/{{ item.source }} \
+    --namespace {{ openshift_project_prefix }}-enforcers \
+    --set nodeAffinity.enabled=true \
+    --set nodeAffinity.mode=required \
+    --set nodeAffinity.key=region \
+    --set nodeAffinity.value=infra \
+    --set nodeAffinity.operator={{ (item.infra | default(false)) | ternary('In', 'NotIn') }} \
+    --set resources.enabled=true \
+    --set resources.limits.memory={{ aporeto_enforcer_memory_limit }} \
+    --set resources.limits.cpu={{ aporeto_enforcer_cpu_limit }} \
+    {{ '--set options.txQueueCount=4' if (item.infra | default(false)) else ''}} \
+    {{ '--set options.rxQueueCount=4' if (item.infra | default(false)) else ''}} \
+    --set options.enableCompressedTags=1 > output/{{ item.target }}"
   ignore_errors: true
+  loop:
+    - source: ds.yaml
+      target: enforcerd_infra_ds.yml
+      infra: true
+    - source: ds.yaml
+      target: enforcerd_ds.yml
+    - source: rbac.yaml
+      target: enforcerd_rbac.yml
+
+- name: Add aporeto-enforced Node Selector to enforcer daemonsets
+  blockinfile:
+    path: 'output/{{ item }}'
+    state: present
+    block: |2
+            nodeSelector:
+              aporeto-enforcerd: 'true'
+    insertbefore: "affinity"
+  loop:
+    - enforcerd_ds.yml
+    - enforcerd_infra_ds.yml
+
+- name: Update enforcerd_infra_ds name
+  lineinfile:
+    path: output/enforcerd_infra_ds.yml
+    regexp: '  name: enforcerd'
+    line: '  name: enforcerd-infra'
+
+- name: Fix Affinity YAML Indentation
+  lineinfile:
+    path: 'output/{{ item }}'
+    regexp: '        requiredDuringSchedulingIgnoredDuringExecution:'
+    line: '          requiredDuringSchedulingIgnoredDuringExecution:'
+  loop:
+    - enforcerd_ds.yml
+    - enforcerd_infra_ds.yml
+
+- lineinfile:
+    path: 'output/{{ item }}'
+    regexp: '          nodeSelectorTerms:'
+    line: '            nodeSelectorTerms:'
+  loop:
+    - enforcerd_ds.yml
+    - enforcerd_infra_ds.yml
 
 - name: Remove helm chart files (cleanup)
   shell: rm -f  enforcerd-*.tgz
 
-- name: Patch daemonset with appropriate label
-  shell: > 
-      ''oc patch daemonset enforcerd -n {{ openshift_project_prefix }}-enforcers -p '{"spec": {"template": {"spec": {"nodeSelector": {"aporeto-enforcerd":"true"}}}}}' ''
-  ignore_errors: true
+- name: Deploy Aporeto Enforcers to OpenShift
+  k8s:
+    namespace: '{{ openshift_project_prefix }}-enforcers'
+    src: 'output/{{ item }}'
+    state: present
+  loop:
+    - enforcerd_rbac.yml
+    - enforcerd_ds.yml
+    - enforcerd_infra_ds.yml
 
 - pause:
     prompt: "Do you want to label the nodes (yes/no)?"

--- a/security/aporeto/build/ansible/tasks/set_env.yml
+++ b/security/aporeto/build/ansible/tasks/set_env.yml
@@ -9,7 +9,13 @@
 - set_fact: 
  #   aporeto_temp_token: "{{ aporeto_temp_token_output.stdout.split('=')[1] }}"
     aporeto_repo: "{{ helm_repo_address }}/releases/release-{{ aporeto_release }}/clients"
+
 - name: Get list of openshift projects
   shell: 
     "oc get projects | awk 'NR>1  {print $1}'"
   register: project_list
+
+- name: Create output directory
+  file:
+    path: output
+    state: directory

--- a/security/aporeto/build/ansible/tasks/uninstall_components.yml
+++ b/security/aporeto/build/ansible/tasks/uninstall_components.yml
@@ -6,21 +6,20 @@
       with_items: 
         - "{{ node_list }}"
       ignore_errors: true
-    - name: Add the helm repo
-      command: "helm repo add {{ helm_repo_name }} {{ aporeto_repo }}"
 
-    - name: Fetch helm charts for enforcers
-      command: "helm fetch aporeto/enforcerd"
-    - name: Use Helm Template to delete OpenShift Objects
-      shell: "helm template enforcerd-*.tgz \
-      --namespace {{ openshift_project_prefix }}-enforcers \
-      | oc delete -f - -n {{ openshift_project_prefix }}-enforcers "
-      ignore_errors: true
+    - name: Remove Aporeto Enforcers from OpenShift
+      k8s:
+        namespace: '{{ openshift_project_prefix }}-enforcers'
+        src: 'output/{{ item }}'
+        state: absent
+      loop:
+        - enforcerd_rbac.yml
+        - enforcerd_ds.yml
+        - enforcerd_infra_ds.yml
 
     - name: Disable Aporeto operator syncing
       command: "oc annotate namespace {{ openshift_project_prefix }}-enforcers aporeto.io/disable-aporeto-ctrls='true' --overwrite"
       ignore_errors: true
-
 
     - name: Remove all custom resources created by the Aporeto Operator
       shell: "for crd in $(oc api-resources --api-group=api.aporeto.io -o name); do oc delete $crd -n {{ openshift_project_prefix }}-enforcers --all ; done"
@@ -44,22 +43,25 @@
       shell: "kubectl delete -f files/bcgov-networksecuritypolicy-operator/crds/definition.yaml"
       ignore_errors: true         #errors show up even though the resources are removed successfully
 
+    - name: Add the helm repo
+      command: "helm repo add {{ helm_repo_name }} {{ aporeto_repo }}"
+
     - name: Fetch helm charts for aporeto-operator
       command: "helm fetch aporeto/aporeto-operator"
+
     - name: Use Helm Template to delete OpenShift Objects
       shell: "helm template aporeto-operator-*.tgz \
         --name aporeto-operator \
         --namespace {{ openshift_project_prefix }}-operator --set options.baseNamespace={{ openshift_project_prefix }}-enforcers \
         | oc delete -f - -n {{ openshift_project_prefix }}-operator"
       ignore_errors: true
-
   
     - name: Fetch helm charts for aporeto-crds
       command: "helm fetch aporeto/aporeto-crds"
+
     - name: Use Helm Template to delete OpenShift Objects
       shell: "helm template aporeto-crds-*.tgz | oc delete -f - "
       ignore_errors: true
 
     - name: Remove OpenShift Projects
       command: "oc delete project {{ openshift_project_prefix }}-enforcers {{ openshift_project_prefix }}-operator"
-


### PR DESCRIPTION
- [x] Adjust tx/rx rate for infra node enforcers to 4
- [x] Add enforcer infra daemonset

It's a quick fix. Enforcer Manifests are now written to the output directory. DaemonSet now uses Affinity to prevent each daemonset from starting on the wrong nodes. Both DaemonSets use the previous node label to simplify changes.