### PR TITLE
Sysdig support recommends this change to improve performance

### DIFF
--- a/monitoring/sysdig/manifests/lab/cm-sysdig-agent-app.yaml
+++ b/monitoring/sysdig/manifests/lab/cm-sysdig-agent-app.yaml
@@ -25,6 +25,7 @@ data:
 
     # Sysdig Case 00005175
     reconnect_max_backoff: 8
+    go_k8s_user_events: false
 
     #######################################
     new_k8s: true

--- a/monitoring/sysdig/manifests/lab/cm-sysdig-agent-infra.yaml
+++ b/monitoring/sysdig/manifests/lab/cm-sysdig-agent-infra.yaml
@@ -25,6 +25,7 @@ data:
 
     # Sysdig Case 00005175
     reconnect_max_backoff: 8
+    go_k8s_user_events: false
 
     #######################################
     new_k8s: true

--- a/monitoring/sysdig/manifests/lab/cm-sysdig-agent-master.yaml
+++ b/monitoring/sysdig/manifests/lab/cm-sysdig-agent-master.yaml
@@ -25,6 +25,7 @@ data:
 
     # Sysdig Case 00005175
     reconnect_max_backoff: 8
+    go_k8s_user_events: false
 
     #######################################
     new_k8s: true

--- a/monitoring/sysdig/manifests/lab/cm-sysdig-agent-storage.yaml
+++ b/monitoring/sysdig/manifests/lab/cm-sysdig-agent-storage.yaml
@@ -25,6 +25,7 @@ data:
 
     # Sysdig Case 00005175
     reconnect_max_backoff: 8
+    go_k8s_user_events: false
 
     #######################################
     new_k8s: true

--- a/monitoring/sysdig/manifests/prod/cm-sysdig-agent-app.yaml
+++ b/monitoring/sysdig/manifests/prod/cm-sysdig-agent-app.yaml
@@ -35,6 +35,7 @@ data:
 
     # Sysdig Case 00005175
     reconnect_max_backoff: 8
+    go_k8s_user_events: false
 
     #######################################
     new_k8s: true

--- a/monitoring/sysdig/manifests/prod/cm-sysdig-agent-infra.yaml
+++ b/monitoring/sysdig/manifests/prod/cm-sysdig-agent-infra.yaml
@@ -35,6 +35,7 @@ data:
 
     # Sysdig Case 00005175
     reconnect_max_backoff: 8
+    go_k8s_user_events: false
 
     #######################################
     new_k8s: true

--- a/monitoring/sysdig/manifests/prod/cm-sysdig-agent-master.yaml
+++ b/monitoring/sysdig/manifests/prod/cm-sysdig-agent-master.yaml
@@ -35,6 +35,7 @@ data:
 
     # Sysdig Case 00005175
     reconnect_max_backoff: 8
+    go_k8s_user_events: false
 
     #######################################
     new_k8s: true

--- a/monitoring/sysdig/manifests/prod/cm-sysdig-agent-storage.yaml
+++ b/monitoring/sysdig/manifests/prod/cm-sysdig-agent-storage.yaml
@@ -35,6 +35,7 @@ data:
 
     # Sysdig Case 00005175
     reconnect_max_backoff: 8
+    go_k8s_user_events: false
 
     #######################################
     new_k8s: true

--- a/monitoring/sysdig/manifests/prod/ds-sysdig-agent-app.yaml
+++ b/monitoring/sysdig/manifests/prod/ds-sysdig-agent-app.yaml
@@ -47,7 +47,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "3"
+            cpu: "4"
             memory: 2Gi
           requests:
             cpu: "1"

--- a/monitoring/sysdig/manifests/prod/ds-sysdig-agent-infra.yaml
+++ b/monitoring/sysdig/manifests/prod/ds-sysdig-agent-infra.yaml
@@ -47,7 +47,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "3"
+            cpu: "4"
             memory: 2Gi
           requests:
             cpu: "1"

--- a/monitoring/sysdig/manifests/prod/ds-sysdig-agent-master.yaml
+++ b/monitoring/sysdig/manifests/prod/ds-sysdig-agent-master.yaml
@@ -47,7 +47,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "3"
+            cpu: "4"
             memory: 2Gi
           requests:
             cpu: "1"

--- a/monitoring/sysdig/manifests/prod/ds-sysdig-agent-storage.yaml
+++ b/monitoring/sysdig/manifests/prod/ds-sysdig-agent-storage.yaml
@@ -47,7 +47,7 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "3"
+            cpu: "4"
             memory: 2Gi
           requests:
             cpu: "1"


### PR DESCRIPTION
Suggestion by Engineering is to disable k8s event using Go language and fall back to C++. The default was change to Go from agent version 0.94 to 9.6, this may cause the agent to use more CPU instead.

Additionally, increase the CPU Limit to 4 cores.