### PR TITLE
Patroni updates to run with changes in latest

### DIFF
--- a/apps/pgsql/patroni/docker/Dockerfile
+++ b/apps/pgsql/patroni/docker/Dockerfile
@@ -19,7 +19,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
     && mkdir -p $PGHOME \
     && sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd \
-
+    # Workaround for dependency version mismatch when running Patroni latest (v1.6.5)
+    && pip3 install urllib3==1.21.1 \
     # Set permissions for OpenShift
     && chmod 775 $PGHOME \
     && chmod 664 /etc/passwd \

--- a/apps/pgsql/patroni/docker/contrib/root/usr/share/scripts/patroni/health_check.sh
+++ b/apps/pgsql/patroni/docker/contrib/root/usr/share/scripts/patroni/health_check.sh
@@ -2,4 +2,5 @@
 set -Eeu
 set -o pipefail
 
-pg_isready -q && patronictl list --format=json | jq -e ".[] | select(.Member == \"$(hostname)\" and .State == \"running\" and .\"Lag in MB\" == 0)"
+pg_isready -q && patronictl list --format=json | \
+    jq -e ".[] | select(.Member == \"$(hostname)\" and .State == \"running\" and (.Role == \"Leader\" or .\"Lag in MB\" == 0))"


### PR DESCRIPTION
Images built from apps/pgsql/patroni use Patroni latest (currently v1.6.5) and the image does not pass health checks.

See https://github.com/BCDevOps/platform-services/issues/692 for details.