### PR TITLE
Add Playbook For Vault License / Audit Log

### DIFF
--- a/security/vault/ansible/playbooks/vault_init.yml
+++ b/security/vault/ansible/playbooks/vault_init.yml
@@ -1,0 +1,21 @@
+- name: Vault License / Audit Init
+  hosts: all
+  gather_facts: false
+  tasks:
+    
+  - name: Ensure Vault License is Set
+    fail:
+      msg: "'VAULT_LICENSE' ENV Variable Must Be Set."
+    when: lookup('env', 'VAULT_LICENSE') | length == 0 
+
+  - name: Apply Vault License
+    hashivault_write:
+      secret: /sys/license
+      data:
+        text: "{{ lookup('env', 'VAULT_LICENSE') }}"
+
+  - name: Enable Vault Audit Log (stdout)
+    hashivault_audit_enable:
+      name: "file"
+      options:
+        file_path: "stdout"

--- a/security/vault/ansible/playbooks/vault_init.yml
+++ b/security/vault/ansible/playbooks/vault_init.yml
@@ -1,4 +1,4 @@
-- name: Vault License / Audit Init
+- name: Vault License / Audit Initialization
   hosts: all
   gather_facts: false
   tasks:

--- a/security/vault/ansible/requirements.txt
+++ b/security/vault/ansible/requirements.txt
@@ -1,0 +1,1 @@
+ansible-modules-hashivault==4.5.4


### PR DESCRIPTION
This PR does the following:

- Adds a `requirements.txt` file for installing additional python modules
- Adds `playbooks/vault-init.yml` which currently just applies the Vault License from the `VAULT_LICENSE` environment variable, and enables the Vault Aduit Log to write to `stdout`.

This will likely end up in another ansible role but for our initial testing this should work. 
