### PR TITLE
Delete Backups Older Than 10 Days & Forbid Concurrency

### DIFF
--- a/security/vault/ansible/roles/vault_backup_install/templates/cronjob-vault-raft-snapshot.yaml.j2
+++ b/security/vault/ansible/roles/vault_backup_install/templates/cronjob-vault-raft-snapshot.yaml.j2
@@ -9,14 +9,17 @@ spec:
     spec:
       template:
         spec:
+          concurrencyPolicy: Forbid
           containers:
           - name: vault
             image: registry.hub.docker.com/library/vault:{{ vault_install_version }}
             command:
               - "/bin/sh"
               - "-c"
+            args:
               # Always Backup even if certificates are expired
-              - "vault operator raft snapshot save -tls-skip-verify /backup/raft-$(date +%Y-%m-%d_%H%M%S).snap"
+              - find /backup -mtime +10 -type f -delete;
+                vault operator raft snapshot save -tls-skip-verify /backup/raft-$(date +%Y-%m-%d_%H%M%S).snap;
             env:
               - name: VAULT_ADDR
                 value: "https://vault-active:8200"


### PR DESCRIPTION
-- Still need to test this in cluster. Works in a local env. 

Todo:
- Switch to ENV var for days to retain
- Remove use of Vault Token once Vault Backup Policy is in place.