### PR TITLE
Debug logging for PROD master/app nodes to feed Sysdig support

### DIFF
--- a/monitoring/sysdig/manifests/prod/cm-sysdig-agent-app.yaml
+++ b/monitoring/sysdig/manifests/prod/cm-sysdig-agent-app.yaml
@@ -8,8 +8,10 @@ data:
     #### Sysdig Software related config ####
     # Agent Log priority
     log:
-      file_priority: info
+      file_priority: debug
       console_priority: warning
+      rotate: 8
+      max_size: 1000
 
     # Watchdog config fr: troubleshooting
     watchdog:

--- a/monitoring/sysdig/manifests/prod/cm-sysdig-agent-master.yaml
+++ b/monitoring/sysdig/manifests/prod/cm-sysdig-agent-master.yaml
@@ -8,8 +8,10 @@ data:
     #### Sysdig Software related config ####
     # Agent Log priority
     log:
-      file_priority: info
+      file_priority: debug
       console_priority: warning
+      rotate: 8
+      max_size: 1000
 
     # Watchdog config (prod only)
     watchdog:


### PR DESCRIPTION
Meant to do this sooner, but it dropped off the mental bandwagon. 

Debug logging enabled for 3.11 PROD master and app nodes only. To feed Sysdig support case 00005175 regarding agent disconnect issues. Is stable with respect to both the agent pod and the nodes in question.

Updates to manifest files were successfully tested/confirmed in PROD to ensure debug logging does get enabled.