### PR TITLE
replace apiVersion for NSPs

### DIFF
--- a/security/aporeto/docs/CustomPolicy.md
+++ b/security/aporeto/docs/CustomPolicy.md
@@ -121,7 +121,7 @@ See the [`samples` file](./sample/quickstart-nsp.yaml) accompanying these instru
 The Kubernetes has an internal API that your environment needs to communicate with to run deployments and for other internal mechanics to work. Change the source namespace in the sample below and apply it.
 
 ```yaml
-apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+apiVersion: security.devops.gov.bc.ca/v1alpha1
 kind: NetworkSecurityPolicy
 metadata:
   name: custom-pods-to-k8s-api-[APP_NAME]
@@ -142,7 +142,7 @@ This sample policy is used to allow pods to communicate within a given namespace
 * API to Database
 
 ```yaml
-apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+apiVersion: security.devops.gov.bc.ca/v1alpha1
 kind: NetworkSecurityPolicy
 metadata:
   name: custom-web2api-permit-[APP_NAME]
@@ -167,7 +167,7 @@ The sample below allows the Web pod(s) to accept connections to from the Interne
 
 ```yaml
 kind: NetworkSecurityPolicy
-apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+apiVersion: security.devops.gov.bc.ca/v1alpha1
 metadata:
   name: custom-external-ingress-[APP_NAME]
 spec:
@@ -193,7 +193,7 @@ The sample below allows the API pod(s) to open connections to any system on the 
 
 ```yaml
 kind: NetworkSecurityPolicy
-apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+apiVersion: security.devops.gov.bc.ca/v1alpha1
 metadata:
   name: custom-internal-egress-[APP_NAME]
 spec:
@@ -219,7 +219,7 @@ The sample below allows the API pod(s) to open connections to a specific pod(s) 
 
 ```yaml
 kind: NetworkSecurityPolicy
-apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+apiVersion: security.devops.gov.bc.ca/v1alpha1
 metadata:
   name: custom-ns2ns-comms-[APP_NAME]
 spec:

--- a/security/aporeto/docs/DeveloperWorkshop.md
+++ b/security/aporeto/docs/DeveloperWorkshop.md
@@ -150,7 +150,7 @@ requests.
 Example: 
 ```
 - kind: NetworkSecurityPolicy
-    apiVersion: secops.pathfinder.gov.bc.ca/ v1alpha
+    apiVersion: security.devops.gov.bc.ca/v1alpha
     metadata:
         name: intra-namespace-comms-uwsgva-dev
         labels:
@@ -172,7 +172,7 @@ Replace with custom policy for each required pod to pod communication.
 Example:
 ```
 - kind: NetworkSecurityPolicy
-    apiVersion: secops.pathfinder.gov.bc.ca/ v1alpha
+    apiVersion: security.devops.gov.bc.ca/v1alpha
     metadata:
         name: intra-namespace-comms-uwsgva-dev
         labels:
@@ -212,7 +212,7 @@ other namespaces
 Example:
 ```
 - kind: NetworkSecurityPolicy
-    apiVersion: secops.pathfinder.gov.bc.ca/v1alpha
+    apiVersion: security.devops.gov.bc.ca/v1alpha
     metadata:
         name: namespace-to-external-network-aajsw-dev
         labels:
@@ -232,7 +232,7 @@ Example:
 
 ```
 - kind: NetworkSecurityPolicy
-    apiVersion: secops.pathfinder.gov.bc.ca/v1alpha
+    apiVersion: security.devops.gov.bc.ca/v1alpha
     metadata:
         name: pod-to-external-network-aajsw-dev
         labels:
@@ -265,7 +265,7 @@ thorough testing
 Example:
 ```
 - kind: NetworkSecurityPolicy
-    apiVersion: secops.pathfinder.gov.bc.ca/v1alpha
+    apiVersion: security.devops.gov.bc.ca/v1alpha
     metadata:
         name: int-cluster-k8s-api-comms-aajsw-dev
     labels:
@@ -284,7 +284,7 @@ Replace with a custom policy for each pod that is required to connect to interna
 Example:
 ```
 - kind: NetworkSecurityPolicy
-    apiVersion: secops.pathfinder.gov.bc.ca/v1alpha
+    apiVersion: security.devops.gov.bc.ca/v1alpha
     metadata:
         name: int-cluster-k8s-api-comms-aajsw-dev
     labels:

--- a/security/aporeto/docs/sample/quickstart-nsp.yaml
+++ b/security/aporeto/docs/sample/quickstart-nsp.yaml
@@ -3,7 +3,7 @@ kind: Template
 parameters:
 - name: NAMESPACE
 objects:
-- apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+- apiVersion: security.devops.gov.bc.ca/v1alpha1
   kind: NetworkSecurityPolicy
   metadata:
     name: egress-internet
@@ -13,7 +13,7 @@ objects:
       - - $namespace=${NAMESPACE}
     destination:
       - - ext:network=any
-- apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+- apiVersion: security.devops.gov.bc.ca/v1alpha1
   kind: NetworkSecurityPolicy
   metadata:
     name: intra-namespace-comms
@@ -23,7 +23,7 @@ objects:
       - - $namespace=${NAMESPACE}
     destination:
       - - $namespace=${NAMESPACE}
-- apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
+- apiVersion: security.devops.gov.bc.ca/v1alpha1
   kind: NetworkSecurityPolicy
   metadata:
     name: int-cluster-k8s-api-comms


### PR DESCRIPTION
Aporeto NetworkSecurityPolicy API object name changed with new deployments in OpenShift 4.  NSP object samples needed updates.

Once merged, a devhub rebuild will update the developer.gov.bc.ca pages.

See BCDevOps/OpenShift4-RollOut#384 for background