### PR TITLE
Update quick start NSP to work on OCP4

### DIFF
--- a/security/aporeto/docs/sample/quickstart-nsp.yaml
+++ b/security/aporeto/docs/sample/quickstart-nsp.yaml
@@ -1,35 +1,65 @@
+# Copyright 2020 The Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
 apiVersion: template.openshift.io/v1
 kind: Template
-parameters:
-- name: NAMESPACE
 objects:
-- apiVersion: security.devops.gov.bc.ca/v1alpha1
-  kind: NetworkSecurityPolicy
-  metadata:
-    name: egress-internet
-  spec:
-    description: "allow ${NAMESPACE} namespace to talk to the internet."
-    source:
-      - - $namespace=${NAMESPACE}
-    destination:
-      - - ext:network=any
-- apiVersion: security.devops.gov.bc.ca/v1alpha1
-  kind: NetworkSecurityPolicy
-  metadata:
-    name: intra-namespace-comms
-  spec:
-    description: "allow ${NAMESPACE} namespace to talk to itself"
-    source:
-      - - $namespace=${NAMESPACE}
-    destination:
-      - - $namespace=${NAMESPACE}
-- apiVersion: security.devops.gov.bc.ca/v1alpha1
-  kind: NetworkSecurityPolicy
-  metadata:
-    name: int-cluster-k8s-api-comms
-  spec:
-    description: "allow ${NAMESPACE} pods to talk to the k8s api"
-    destination:
-    - - int:network=internal-cluster-api-endpoint
-    source:
-    - - $namespace=${NAMESPACE}
+  - apiVersion: security.devops.gov.bc.ca/v1alpha1
+    kind: ExternalNetwork
+    metadata:
+      # This metadata field will be what you see with the command
+      # `oc get externalnetwork` or `kubctl get externalnetwork`.
+      name: all-things-external
+    spec:
+      # This name will be used internally by Aporeto; it should match
+      # the `name` field in metadata above.
+      description: |
+        specify a custom external network that can be
+        referenced by name.
+      entries:
+        - 0.0.0.0/0
+      servicePorts:
+        - "tcp/80"
+        - "tcp/443"
+  - apiVersion: security.devops.gov.bc.ca/v1alpha1
+    kind: NetworkSecurityPolicy
+    metadata:
+      name: pods-to-internet
+    spec:
+      description: |
+        allow anything in ${NAMESPACE} to talk out to the internet
+        via the custom external network.
+      source:
+        - - $namespace=${NAMESPACE}
+      destination:
+        - - ext:name=all-things-external
+  - apiVersion: security.devops.gov.bc.ca/v1alpha1
+    kind: NetworkSecurityPolicy
+    metadata:
+      name: intra-namespace-comms
+    spec:
+      description: |
+        allow anything in ${NAMESPACE} to talk to anything else in the
+        same namespace.
+      source:
+        - - $namespace=${NAMESPACE}
+      destination:
+        - - $namespace=${NAMESPACE}
+parameters:
+  - name: NAMESPACE
+    description: |
+      The the name of the namespace the policy is being
+      deployed to.
+    required: true


### PR DESCRIPTION
This shores up the quick start NSP so that it remains open, but restricts outbound comms to port 80 and 443 only. If teams want to ssh or connect to external DBs they'll nee to put a bit of though into specifically opening those ports.