### PR TITLE
Vendor recommended version upgrade

### DIFF
--- a/monitoring/sysdig/manifests/lab/ds-sysdig-agent-app.yaml
+++ b/monitoring/sysdig/manifests/lab/ds-sysdig-agent-app.yaml
@@ -20,7 +20,7 @@ spec:
         app_group: sysdig-agent-app
     spec:
       containers:
-      - image: sysdig/agent:10.3.1
+      - image: sysdig/agent:10.5.2
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/monitoring/sysdig/manifests/lab/ds-sysdig-agent-infra.yaml
+++ b/monitoring/sysdig/manifests/lab/ds-sysdig-agent-infra.yaml
@@ -20,7 +20,7 @@ spec:
         app_group: sysdig-agent-infra
     spec:
       containers:
-      - image: sysdig/agent:10.3.1
+      - image: sysdig/agent:10.5.2
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/monitoring/sysdig/manifests/lab/ds-sysdig-agent-master.yaml
+++ b/monitoring/sysdig/manifests/lab/ds-sysdig-agent-master.yaml
@@ -20,7 +20,7 @@ spec:
         app_group: sysdig-agent-master
     spec:
       containers:
-      - image: sysdig/agent:10.3.1
+      - image: sysdig/agent:10.5.2
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/monitoring/sysdig/manifests/prod/ds-sysdig-agent-app.yaml
+++ b/monitoring/sysdig/manifests/prod/ds-sysdig-agent-app.yaml
@@ -20,7 +20,7 @@ spec:
         app_group: sysdig-agent-app
     spec:
       containers:
-      - image: sysdig/agent:10.3.1
+      - image: sysdig/agent:10.5.2
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/monitoring/sysdig/manifests/prod/ds-sysdig-agent-infra.yaml
+++ b/monitoring/sysdig/manifests/prod/ds-sysdig-agent-infra.yaml
@@ -20,7 +20,7 @@ spec:
         app_group: sysdig-agent-infra
     spec:
       containers:
-      - image: sysdig/agent:10.3.1
+      - image: sysdig/agent:10.5.2
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/monitoring/sysdig/manifests/prod/ds-sysdig-agent-master.yaml
+++ b/monitoring/sysdig/manifests/prod/ds-sysdig-agent-master.yaml
@@ -20,7 +20,7 @@ spec:
         app_group: sysdig-agent-master
     spec:
       containers:
-      - image: sysdig/agent:10.3.1
+      - image: sysdig/agent:10.5.2
         imagePullPolicy: Always
         livenessProbe:
           exec:


### PR DESCRIPTION
Agent upgrade request made by Sysdig per case 00007628 as a means of providing additional data in log files for tracking down remaining short disconnect events seen by the SaaS.

Applied the DS manifest files to 3.11 LAB from this branch. Do not merge/apply in PROD until confirmation that PROD maintenance is finished (OCP upgrade underway). I plan on dealing with the PROD upgrade for sysdig agent when I return from vacation on November 16th.