### PR TITLE
Update dockerhub account for Rocketchat

### DIFF
--- a/apps/rocketchat/template-sa-linked-image-pull-secrets.yaml
+++ b/apps/rocketchat/template-sa-linked-image-pull-secrets.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: rocketchat-dockerhub-account-template
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: dockerhub-account-rocketchat
+    namespace: ${NAMESPACE}
+  type: Opaque 
+  stringData: 
+    docker-username: ${DOCKER_USERNAME}
+    docker-password: ${DOCKER_PW}
+    docker-email: unused
+    docker-server: ${DOCKER_SERVER}
+- apiVersion: v1
+  kind: ServiceAccount
+  imagePullSecrets: 
+  - name: dockerhub-account-rocketchat
+  metadata:
+    name: builder
+    namespace: ${NAMESPACE}
+- apiVersion: v1
+  kind: ServiceAccount
+  imagePullSecrets: 
+  - name: dockerhub-account-rocketchat
+  metadata:
+    name: default
+    namespace: ${NAMESPACE}
+parameters:
+- description: Namespace
+  displayName: namespace
+  name: NAMESPACE
+  required: true
+- description: Docker Username
+  displayName: Docker Username
+  name: DOCKER_USERNAME
+  required: true
+- description: Docker Password
+  displayName: Docker Password
+  name: DOCKER_PW
+  required: true
+- description: Docker Server
+  displayName: Docker Server
+  name: DOCKER_SERVER
+  required: true


### PR DESCRIPTION
## Summary
The Docker account to pull images for Rocketchat needs to be updated to the paid Docker account `bcgovdevops` to solve the rate-limit issue.