### PR TITLE
Update rocketchat docker secret to use dockerconfig.json

### DIFF
--- a/apps/rocketchat/template-sa-linked-image-pull-secrets.yaml
+++ b/apps/rocketchat/template-sa-linked-image-pull-secrets.yaml
@@ -9,12 +9,10 @@ objects:
   metadata:
     name: dockerhub-account-rocketchat
     namespace: ${NAMESPACE}
-  type: Opaque 
-  stringData: 
-    docker-username: ${DOCKER_USERNAME}
-    docker-password: ${DOCKER_PW}
-    docker-email: unused
-    docker-server: ${DOCKER_SERVER}
+  type: kubernetes.io/dockerconfigjson
+  stringData:
+    .dockerconfigjson: >-
+      {"auths":{"${DOCKER_SERVER}":{"username":"${DOCKER_USERNAME}","password":"${DOCKER_PW}","email":"unused","auth":"dGVzdDp0ZXN0Mg=="}}}
 - apiVersion: v1
   kind: ServiceAccount
   imagePullSecrets: 


### PR DESCRIPTION
The original secret type is "opaque". This has been modified to "kubernetes.io/dockerconfigjson" as per documentation in BCDevOps/OpenShift4-Migration#51