### PR TITLE
Aporeto readme update

### DIFF
--- a/security/aporeto/readme.md
+++ b/security/aporeto/readme.md
@@ -17,7 +17,7 @@ Users with [appropriate permissions](./architecture/design_decisions.md#access-t
 - URL: https://console.aporeto.com
 - Select the sign in options (three dots) and select *Sign in with OIDC*
   - Namespace: /bcgov
-  - Provider: pathfinder-sso-prod
+  - Provider *(optional - leave blank for default)*: oidc
 
 **:point_up: Note**
 


### PR DESCRIPTION
quick update to fix aporeto sign-in reference to old OIDC name.