### PR TITLE
Aqua post config update

### DIFF
--- a/.github/workflows/aqua-post-deploy-build.yaml
+++ b/.github/workflows/aqua-post-deploy-build.yaml
@@ -25,4 +25,4 @@ jobs:
     - name: Build the tagged Docker image
       run: cd apps/aqua-post-config && docker build . --file Dockerfile --tag bcdevopscluster/aqua-post-config:lab
     - name: Push the tagged Docker image
-      run: docker push bcdevopscluster/aqua-post-config:lab
+      run: docker push bcdevopscluster/aqua-post-config:1.0.0-alpha

--- a/apps/aqua-post-config/playbook/tasks/enable_enforcers.yaml
+++ b/apps/aqua-post-config/playbook/tasks/enable_enforcers.yaml
@@ -11,7 +11,8 @@
     status_code: [200]
     url: "{{ aqua_url }}/api/v1/hosts"
   until: response.json.result | length > 0
-
+  retries: 5
+  delay: 10
 - name: Approve Enforcer to default group
   uri:
     headers:

--- a/apps/aqua-post-config/playbook/tasks/enable_enforcers.yaml
+++ b/apps/aqua-post-config/playbook/tasks/enable_enforcers.yaml
@@ -10,7 +10,7 @@
     method: GET
     status_code: [200]
     url: "{{ aqua_url }}/api/v1/hosts"
-
+  until: response.json.result | length > 0
 
 - name: Approve Enforcer to default group
   uri:


### PR DESCRIPTION
## Summary

introduced an until statement so that aqua enforcers get approved correctly in the case the container spins up before enforcers do in the automation process with argo

also updated image version to alpha