### PR TITLE
Sysdig - enable events for all teams

### DIFF
--- a/monitoring/sysdig/operator/sysdig-monitor/roles/sysdigteam/templates/existing_container_team.json.j2
+++ b/monitoring/sysdig/operator/sysdig-monitor/roles/sysdigteam/templates/existing_container_team.json.j2
@@ -1,6 +1,6 @@
 {   
   "canUseAwsMetrics": false,
-  "canUseCustomEvents": false,
+  "canUseCustomEvents": true,
   "canUseSysdigCapture": false,
   "description": "{{ team.description }}",
   "name": "{{ container_team_name }}",

--- a/monitoring/sysdig/operator/sysdig-monitor/roles/sysdigteam/templates/existing_host_team.json.j2
+++ b/monitoring/sysdig/operator/sysdig-monitor/roles/sysdigteam/templates/existing_host_team.json.j2
@@ -1,6 +1,6 @@
 {   
   "canUseAwsMetrics": false,
-  "canUseCustomEvents": false,
+  "canUseCustomEvents": true,
   "canUseSysdigCapture": false,
   "description": "{{ team.description }} Persistent Storage",
   "name": "{{ host_team_name }}",

--- a/monitoring/sysdig/operator/sysdig-monitor/roles/sysdigteam/templates/new_container_team.json.j2
+++ b/monitoring/sysdig/operator/sysdig-monitor/roles/sysdigteam/templates/new_container_team.json.j2
@@ -1,7 +1,7 @@
 
 {   
     "canUseAwsMetrics": false,
-    "canUseCustomEvents": false,
+    "canUseCustomEvents": true,
     "canUseSysdigCapture": false,
     "default": false,
     "description": "{{ team.description }}",

--- a/monitoring/sysdig/operator/sysdig-monitor/roles/sysdigteam/templates/new_host_team.json.j2
+++ b/monitoring/sysdig/operator/sysdig-monitor/roles/sysdigteam/templates/new_host_team.json.j2
@@ -1,7 +1,7 @@
 
 {   
     "canUseAwsMetrics": false,
-    "canUseCustomEvents": false,
+    "canUseCustomEvents": true,
     "canUseSysdigCapture": false,
     "default": false,
     "description": "{{ team.description }} Persistent Storage",


### PR DESCRIPTION
Issue (https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/bcdevops/developer-experience/1614) has been fixed from sysdig side now. We are good to enable events for all teams.