### PR TITLE
Patroni Legacy Dockerfile update

### DIFF
--- a/apps/pgsql/patroni/docker/Dockerfile
+++ b/apps/pgsql/patroni/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && set -x \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
     && apt-get update -y \
-    && apt-get install -y curl jq locales libpq-fe.h git build-essential python3 python3-dev python3-pip python3-wheel python3-setuptools python3-virtualenv \
+    && apt-get install -y curl jq locales libpq-dev git build-essential python3 python3-dev python3-pip python3-wheel python3-setuptools python3-virtualenv \
     && echo 'Make sure we have a en_US.UTF-8 locale available' \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && pip3 --isolated --no-cache-dir install psycopg2-binary \


### PR DESCRIPTION
Dockerfile was failing to build due to a missing python dependancy libpq-dev 