### PR TITLE
add arg to dockerfile

### DIFF
--- a/apps/pgsql/patroni/docker/Dockerfile
+++ b/apps/pgsql/patroni/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgres:11
-MAINTAINER Alexander Kukushkin <alexander.kukushkin@zalando.de>
-ENV PATRONI_VERSION=1.6.5
+ARG patroniv=1.6.5
+ENV PATRONI_VERSION=$patroniv
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 ENV PATRONI_HOME=/opt/patroni
 


### PR DESCRIPTION
This update is part of the fix for the patroni 1.6.5 crashing issue that came up during patching recently. Teams using this docker file will see no change to their image with this update, but it allows teams to add a buildarg to their buildconfig so they can update the patroni version to a fixed version number. I will also be updating the new version of this file in https://github.com/bcgov/patroni-postgres-container/blob/master/Dockerfile